### PR TITLE
actualiza gradle para correr en android

### DIFF
--- a/Workshop/android/gradle/wrapper/gradle-wrapper.properties
+++ b/Workshop/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
con este cambio logro levantar la app desde win10 de inmediato después de instalar:
`npm install && npx react-native run-android`